### PR TITLE
Fix kernel build with glibc 2.34

### DIFF
--- a/config/BoardConfigKernel.mk
+++ b/config/BoardConfigKernel.mk
@@ -127,8 +127,6 @@ endif
 
 ifeq ($(HOST_OS),darwin)
   KERNEL_MAKE_FLAGS += HOSTCFLAGS="-I$(BUILD_TOP)/external/elfutils/libelf -I/usr/local/opt/openssl/include -L/usr/local/opt/openssl/lib"
-else
-  KERNEL_MAKE_FLAGS += CPATH="/usr/include:/usr/include/x86_64-linux-gnu" HOSTCFLAGS="-L/usr/lib/x86_64-linux-gnu -L/usr/lib64"
 endif
 
 ifneq ($(TARGET_KERNEL_ADDITIONAL_FLAGS),)


### PR DESCRIPTION
Fix building error
error: undefined reference to '__libc_csu_fini'
error: undefined reference to '__libc_csu_fini'